### PR TITLE
Prevent NullPointerException when value is set while component is detached

### DIFF
--- a/collaboration-engine-test/collaboration-engine-test-common/src/main/java/com/vaadin/collaborationengine/ReattachFieldTestCommon.java
+++ b/collaboration-engine-test/collaboration-engine-test-common/src/main/java/com/vaadin/collaborationengine/ReattachFieldTestCommon.java
@@ -28,6 +28,10 @@ public class ReattachFieldTestCommon
         ClientState client2 = new ClientState(addClient());
 
         client1.detachTextField();
+        // Value may or may not be propagated to the other client,
+        // but no exception should be thrown
+        client1.textField.setValue("bar");
+
         client2.detachTextField();
 
         client1.attachTextField();

--- a/collaboration-engine-test/collaboration-engine-test-common/src/main/java/com/vaadin/collaborationengine/ReattachFieldTestCommon.java
+++ b/collaboration-engine-test/collaboration-engine-test-common/src/main/java/com/vaadin/collaborationengine/ReattachFieldTestCommon.java
@@ -28,10 +28,6 @@ public class ReattachFieldTestCommon
         ClientState client2 = new ClientState(addClient());
 
         client1.detachTextField();
-        // Value may or may not be propagated to the other client,
-        // but no exception should be thrown
-        client1.textField.setValue("bar");
-
         client2.detachTextField();
 
         client1.attachTextField();

--- a/collaboration-engine/src/main/java/com/vaadin/collaborationengine/TopicConnection.java
+++ b/collaboration-engine/src/main/java/com/vaadin/collaborationengine/TopicConnection.java
@@ -118,8 +118,10 @@ public class TopicConnection {
                         cleanupScopedData();
                     }
                 }
-                actionDispatcher
-                        .dispatchAction(() -> contextFuture.complete(null));
+                if (actionDispatcher != null) {
+                    actionDispatcher
+                            .dispatchAction(() -> contextFuture.complete(null));
+                }
             });
             actionDispatcher
                     .dispatchAction(() -> distributor.accept(id, change));
@@ -142,8 +144,10 @@ public class TopicConnection {
                         cleanupScopedData();
                     }
                 }
-                actionDispatcher.dispatchAction(() -> contextFuture
-                        .complete(result != ChangeResult.REJECTED));
+                if (actionDispatcher != null) {
+                    actionDispatcher.dispatchAction(() -> contextFuture
+                            .complete(result != ChangeResult.REJECTED));
+                }
             });
             actionDispatcher
                     .dispatchAction(() -> distributor.accept(id, change));
@@ -345,8 +349,10 @@ public class TopicConnection {
                         cleanupScopedData();
                     }
                 }
-                actionDispatcher.dispatchAction(() -> contextFuture
-                        .complete(result != ChangeResult.REJECTED));
+                if (actionDispatcher != null) {
+                    actionDispatcher.dispatchAction(() -> contextFuture
+                            .complete(result != ChangeResult.REJECTED));
+                }
             });
             actionDispatcher
                     .dispatchAction(() -> distributor.accept(id, change));


### PR DESCRIPTION
## Description

If a component is used to create a `ComponentConnectionContext` and it's value is set immediately after it is detached from a UI, it may be that the value is propagated and it receives a confirmation message, by which time the connection has been closed. This causes a `NullPointerException` on the `actionDispatcher` within `TopicConnection`.

This prevents the exception by doing a `null` check. If the `actionDispatcher` is null, nothing is done. This is a valid strategy as the confirmation of a value change is irrelevant once the connection is closed.

Fixes #80

## Type of change

- [x] Bugfix
- [ ] Feature
