### PR TITLE
chore: Bump Flow and components to 24.8

### DIFF
--- a/collaboration-engine-test/pom.xml
+++ b/collaboration-engine-test/pom.xml
@@ -19,9 +19,9 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <!-- test dependencies versions -->
         <servlet-api.version>6.0.0</servlet-api.version>
-        <spring-boot.version>3.4.0</spring-boot.version>
+        <spring-boot.version>3.5.3</spring-boot.version>
         <flow.cdi.version>15.0-SNAPSHOT</flow.cdi.version>
-        <testbench.version>9.3.12</testbench.version>
+        <testbench.version>9.4.1</testbench.version>
         <!-- selenium is so much verbose -->
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     </properties>

--- a/collaboration-engine/src/main/java/com/vaadin/collaborationengine/CollaborationMessageList.java
+++ b/collaboration-engine/src/main/java/com/vaadin/collaborationengine/CollaborationMessageList.java
@@ -331,6 +331,7 @@ public class CollaborationMessageList extends Composite<MessageList>
     public MessageConfigurator getMessageConfigurator() {
         return messageConfigurator;
     }
+
     /**
      * Wrapper method for {@link MessageList#setMarkdown(boolean)}. Sets whether
      * the messages should be parsed as markdown. By default this is set to

--- a/collaboration-engine/src/main/java/com/vaadin/collaborationengine/CollaborationMessageList.java
+++ b/collaboration-engine/src/main/java/com/vaadin/collaborationengine/CollaborationMessageList.java
@@ -331,6 +331,51 @@ public class CollaborationMessageList extends Composite<MessageList>
     public MessageConfigurator getMessageConfigurator() {
         return messageConfigurator;
     }
+    /**
+     * Wrapper method for {@link MessageList#setMarkdown(boolean)}. Sets whether
+     * the messages should be parsed as markdown. By default this is set to
+     * {@code false}.
+     *
+     * @param markdown
+     *            {@code true} if the message text is parsed as Markdown.
+     */
+    public void setMarkdown(boolean markdown) {
+        this.getContent().setMarkdown(markdown);
+    }
+
+    /**
+     * Wrapper method for {@link MessageList#isMarkdown()}. Returns whether the
+     * messages are parsed as markdown.
+     *
+     * @return {@code true} if the message text is parsed as Markdown.
+     */
+    public boolean isMarkdown() {
+        return this.getContent().isMarkdown();
+    }
+
+    /**
+     * Wrapper method for {@link MessageList#setAnnounceMessages(boolean)}. When
+     * set to {@code true}, new messages are announced to assistive technologies
+     * using ARIA live regions. By default, this is set to {@code false}.
+     *
+     * @param announceMessages
+     *            {@code true} if new messages should be announced to assistive
+     *            technologies.
+     */
+    public void setAnnounceMessages(boolean announceMessages) {
+        this.getContent().setAnnounceMessages(announceMessages);
+    }
+
+    /**
+     * Wrapper method for {@link MessageList#isAnnounceMessages()}. Returns
+     * whether new messages are announced to assistive technologies.
+     *
+     * @return {@code true} if new messages are announced to assistive
+     *         technologies.
+     */
+    public boolean isAnnounceMessages() {
+        return this.getContent().isAnnounceMessages();
+    }
 
     private void refreshMessages() {
         List<MessageListItem> messageListItems = messageCache.stream()

--- a/collaboration-engine/src/test/java/com/vaadin/collaborationengine/CollaborationMessageListTest.java
+++ b/collaboration-engine/src/test/java/com/vaadin/collaborationengine/CollaborationMessageListTest.java
@@ -582,6 +582,7 @@ public class CollaborationMessageListTest {
     public void setAnnounceMessagesEnabled_announceMessagesIsEnabled() {
         client1.messageList.setAnnounceMessages(true);
         Assert.assertTrue(client1.messageList.isAnnounceMessages());
-        Assert.assertTrue(client1.messageList.getContent().isAnnounceMessages());
+        Assert.assertTrue(
+                client1.messageList.getContent().isAnnounceMessages());
     }
 }

--- a/collaboration-engine/src/test/java/com/vaadin/collaborationengine/CollaborationMessageListTest.java
+++ b/collaboration-engine/src/test/java/com/vaadin/collaborationengine/CollaborationMessageListTest.java
@@ -210,7 +210,7 @@ public class CollaborationMessageListTest {
     }
 
     private static List<String> blackListedMethods = Arrays.asList("getItems",
-            "setItems", "localeChange");
+            "setItems", "addItem", "localeChange");
 
     @Test
     public void messageList_replicateRelevantAPIs() {
@@ -569,5 +569,19 @@ public class CollaborationMessageListTest {
 
         CollaborationMessageList deserializedMessageList = TestUtils
                 .serialize(messageList);
+    }
+
+    @Test
+    public void setMarkdownEnabled_markdownIsEnabled() {
+        client1.messageList.setMarkdown(true);
+        Assert.assertTrue(client1.messageList.isMarkdown());
+        Assert.assertTrue(client1.messageList.getContent().isMarkdown());
+    }
+
+    @Test
+    public void setAnnounceMessagesEnabled_announceMessagesIsEnabled() {
+        client1.messageList.setAnnounceMessages(true);
+        Assert.assertTrue(client1.messageList.isAnnounceMessages());
+        Assert.assertTrue(client1.messageList.getContent().isAnnounceMessages());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -36,14 +36,14 @@
 
         <!-- Versions to keep in sync with the targeted platform version: -->
         <!-- spring,cdi versions has been moved to test module. -->
-        <flow.version>24.6-SNAPSHOT</flow.version>
-        <vaadin.component.version>24.6-SNAPSHOT</vaadin.component.version>
+        <flow.version>24.8-SNAPSHOT</flow.version>
+        <vaadin.component.version>24.8-SNAPSHOT</vaadin.component.version>
         <vaadin.lumo.version>${vaadin.component.version}</vaadin.lumo.version>
 
         <!-- Keep in sync with flow-server: -->
-        <jackson.version>2.17.1</jackson.version>
+        <jackson.version>2.19.1</jackson.version>
         <junit.version>4.13.2</junit.version>
-        <jetty.version>11.0.20</jetty.version>
+        <jetty.version>11.0.25</jetty.version>
 
         <!-- plugin versions -->
         <spotless.plugin.version>2.43.0</spotless.plugin.version>


### PR DESCRIPTION
## Description

Updates the Flow and component versions to 24.8.
The latest version of `MessageList` in Flow introduces some new methods which need to be wrapped by `CollaborationMessageList`.