### PR TITLE
Added explicit Lumo import

### DIFF
--- a/collaboration-engine-demo/pom.xml
+++ b/collaboration-engine-demo/pom.xml
@@ -105,6 +105,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-field-highlighter-flow</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <version>5.0.0</version>

--- a/collaboration-engine-demo/src/main/java/com/vaadin/DemoView.java
+++ b/collaboration-engine-demo/src/main/java/com/vaadin/DemoView.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.communication.PushMode;
 
 @Route("")
+@CssImport("@vaadin/vaadin-lumo-styles/lumo.css")
 @CssImport("./styles/shared-styles.css")
 public class DemoView extends VerticalLayout {
 


### PR DESCRIPTION
## Description

This adds an explicit import for the Lumo styles as application themes are no longer based on Lumo.
Also adds an explicit dependency for the field highlighter.

Fixes #107 

## Type of change

- [x] Bugfix
- [ ] Feature